### PR TITLE
Serde CBOR and specialization for T: DocumentLike + Id

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,16 @@ categories = ["database-implementations", "data-structures"]
 
 [dependencies]
 tantivy = "0.12"
-sled = { version = "0.31", path = "../sled" }
-bincode = "1"
+sled = { version = "0.31"}
+bincode = { version =  "1", optional = true }
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 rayon = "1"
 pallet-macros = { path = "./pallet-macros", version = "0.4" }
 tempfile = "3.1"
+serde_cbor ={ version =  "0.11.1", optional = true }
+
+[features]
+default = []
+serde-bincode = ["bincode"]
+cbor = ["serde_cbor"]

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 extern crate serde;
 
+use pallet::CollectionStore;
+
 #[derive(Serialize, Deserialize, Debug, pallet::DocumentLike)]
 #[pallet(tree_name = "books")]
 pub struct Book {

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 use std::sync::Mutex;
-use crate::{err, Document, DocumentLike, Store};
+use crate::{err, Document, DocumentLike, Store, CollectionStore};
 
 mod as_query;
 mod field_value;

--- a/src/search/params.rs
+++ b/src/search/params.rs
@@ -11,34 +11,34 @@ pub struct Collector<T>(pub(crate) T);
 pub struct Handler<T>(pub(crate) T);
 
 /**
-Builder to prepare search execution
-
-## Usage:
-
-```rust
-use pallet::{err, search, Store, DocumentLike};
-
-fn search<T: DocumentLike>(store: &Store<T>, query: &str) -> err::Result<search::Results<T>> {
-    let scored_ids_handle = search::ScoredIds { size_hint: None, id_field: store.index.id_field };
-    let count_handle = tantivy::collector::Count;
-
-    let search_params = search::Params::default()
-        .with_query(query)
-        .with_collector((count_handle, scored_ids_handle))
-        .with_handler(|(count, scored_ids)| -> err::Result<_> {
-            let hits = scored_ids
-                .into_iter()
-                .map(|search::ScoredId { id, score }| {
-                    store.find(id).map(|opt_doc| opt_doc.map(|doc| search::Hit { doc, score }))
-                })
-                .filter_map(Result::transpose)
-                .collect::<err::Result<Vec<_>>>()?;
-
-            Ok(search::Results { count, hits })
-        });
-    Ok(store.search(search_params)?)
-}
-```
+* Builder to prepare search execution
+*
+* ## Usage:
+*
+* ```rust
+* use pallet::{err, search, Store, DocumentLike, CollectionStore};
+*
+* fn search<T: DocumentLike>(store: &Store<T>, query: &str) -> err::Result<search::Results<T>> {
+*     let scored_ids_handle = search::ScoredIds { size_hint: None, id_field: store.index.id_field };
+*     let count_handle = tantivy::collector::Count;
+*
+*     let search_params = search::Params::default()
+*         .with_query(query)
+*         .with_collector((count_handle, scored_ids_handle))
+*         .with_handler(|(count, scored_ids)| -> err::Result<_> {
+*             let hits = scored_ids
+*                 .into_iter()
+*                 .map(|search::ScoredId { id, score }| {
+*                     store.find(id).map(|opt_doc| opt_doc.map(|doc| search::Hit { doc, score }))
+*                 })
+*                 .filter_map(Result::transpose)
+*                 .collect::<err::Result<Vec<_>>>()?;
+*
+*             Ok(search::Results { count, hits })
+*         });
+*     Ok(store.search(search_params)?)
+* }
+* ```
 */
 pub struct Params<Q, C, H> {
     pub(crate) query: Q,


### PR DESCRIPTION
Hi, I made a few changes as per my requirement and would like to make these changes available upstream.

My reason for adding CBOR was because bincode couldn't deserialize nested enum items.
I added specialization so that types which want to implement their own ids can do so.

It also seems that you have made some changes in your copy of repo itself and I will try to fix the merge conflict myself soon.