### PR TITLE
Upgrade depedencies (tantivy, sled), clean up Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,22 +7,21 @@ license = "MIT"
 description = "Document store built with sled and tantivy"
 readme = "README.md"
 repository = "https://github.com/kardeiz/pallet"
-keywords = ["database", "datastore", "search", "tantivy", "sled", ]
+keywords = ["database", "datastore", "search", "tantivy", "sled"]
 categories = ["database-implementations", "data-structures"]
 
 [dependencies]
-tantivy = "0.12"
-sled = { version = "0.31"}
-bincode = { version =  "1", optional = true }
+tantivy = "0.14"
+sled = { version = "0.34.6" }
+bincode = { version = "1", optional = true }
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 rayon = "1"
 pallet-macros = { path = "./pallet-macros", version = "0.4" }
-tempfile = "3.1"
-serde_cbor ={ version =  "0.11.1", optional = true }
+serde_cbor = { version = "0.11.1", optional = true }
+
+[dev-dependencies]
+tempfile = "3.2"
 
 [features]
 default = ["bincode"]
-
-[patch.crates-io]
-sled = { git = 'https://github.com/kardeiz/sled', branch = 'wsl-fix' }

--- a/src/search/scored_ids.rs
+++ b/src/search/scored_ids.rs
@@ -30,7 +30,7 @@ impl tantivy::collector::Collector for ScoredIds {
     ) -> tantivy::Result<Self::Child> {
         Ok(ScoredIdsSegmentCollector {
             buffer: self.size_hint.map(Vec::with_capacity).unwrap_or_else(Vec::new),
-            id_field_reader: segment.fast_fields().u64(self.id_field.clone()),
+            id_field_reader: segment.fast_fields().u64(self.id_field.clone()).ok(),
         })
     }
 


### PR DESCRIPTION
This PR upgrades the versions of `tantivy` and `sled` to their latest respective versions, addressing the issue where the current state of the crate is unable to build. This also removes the need to patch the `sled` crate as those changes have been upstreamed.

I've also upgrade and moved the `tempfile` dependency to a dev-dependency as it's only used in an example.

There were a few minor breaking changes to both `tantivy` and `sled`. I'm not 100% familiar with these crates so I have only done work to get the example to build and run, so not sure about any subtle bugs I may have introduced. My main concern is with how IDs are now generated from a `TransactionalTree`, required to not hang inside of a transaction context.